### PR TITLE
Added support for connecting as a privileged user

### DIFF
--- a/lib/infrataster/contexts/oracledb_query_context.rb
+++ b/lib/infrataster/contexts/oracledb_query_context.rb
@@ -15,10 +15,19 @@ module Infrataster
         end
 
         server.forward_port(options[:port]) do |address, new_port|
-          conn = OCI8.new(
-            options[:user], options[:password],
-            "//#{address}:#{new_port}/#{options[:service_name]}"
-          )
+          if options.has_key?(:privilege) then
+            conn = OCI8.new(
+              options[:user], options[:password],
+              "//#{address}:#{new_port}/#{options[:service_name]}",
+              options[:privilege]
+            )
+          else
+            conn = OCI8.new(
+              options[:user], options[:password],
+              "//#{address}:#{new_port}/#{options[:service_name]}"
+            )
+          end
+
           cursor = conn.parse(resource.query)
           cursor.exec()
 


### PR DESCRIPTION
Make it possible to set "privilege:" in options for a resource
#### e.g.

```
Infrataster::Server.define(
  :orcl,
  '192.168.56.101',
  oracledb: {user: 'sys', password: 'oracle', 
             service_name: 'orcl', privilege: :SYSDBA},
)
```
